### PR TITLE
Silent error on current round

### DIFF
--- a/app/controllers/sessions.js
+++ b/app/controllers/sessions.js
@@ -66,6 +66,8 @@ var SessionsController = Ember.Controller.extend({
 
           var nextUnplayedHole = round.get('scorecards.firstObject.nextUnplayedTurn.holeNumber');
           _this.controllerFor('application').set('currentHole', nextUnplayedHole);
+        }, function(error) {
+          // Do nothing if there is no current round
         });
 
         if (attemptedTransition) {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -24,6 +24,8 @@ var ApplicationRoute = Ember.Route.extend({
 
       var nextUnplayedHole = round.get('scorecards.firstObject.nextUnplayedTurn.holeNumber');
       _this.controllerFor('application').set('currentHole', nextUnplayedHole);
+    }, function(error) {
+      // Do nothing if there is no current round
     });
   }
 });


### PR DESCRIPTION
- We don’t really want or need to throw an error if our server can not
  find the “current round”, because often there is no “current round”
  [Closes frolfr/frolfr-server#146]

@killpack @pdougall1 do we think this is a "bad way" to handle this kind of error?
