### PR TITLE
Temporary downgrade to most stable version of minor release (1.13)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "frolfr-client",
   "dependencies": {
-    "ember": "1.13.11",
+    "ember": "1.13.0",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
     "ember-data": "1.13.15",


### PR DESCRIPTION
- Frustratingly, ember test, ember build, and ember deploy (anything
  that relies on phantom.js) stalls forever with this version of Ember.
- See https://github.com/frolfr/frolfr-server/issues/198
